### PR TITLE
feat: add centralized WebSocket request client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_WS_URL=ws://localhost:8000/apiws

--- a/src/a/A_app.js
+++ b/src/a/A_app.js
@@ -1,5 +1,5 @@
 import {useEffect, useState} from "react"
-import {connectWebSocket, sendWS, subscribeWS} from "../utils/Websocket"
+import {connectWebSocket} from "../utils/Websocket"
 import ServerError from "../system-pages/ServerError"
 import Loader from "../utils/Loaders"
 import Login from "./auth/Login";

--- a/src/a/A_app.js
+++ b/src/a/A_app.js
@@ -33,7 +33,7 @@ export default function App_a() {
     useEffect(() => {
         if (status !== "connected") return
         if (localStorage.getItem("usr_acc") && localStorage.getItem("device_token")) {
-            setPage("auth")
+            setPage("main")
 
         } else {
             setPage("auth")

--- a/src/a/auth/Login.js
+++ b/src/a/auth/Login.js
@@ -1,18 +1,31 @@
 import {useEffect, useState} from 'react';
-import { Box, Card, CardContent, Typography, TextField, Button, useMediaQuery } from '@mui/material';
+import { Box, Card, CardContent, Typography, TextField, Button, useMediaQuery, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
+import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
 import Footer from "../../components/Footer";
 import {showError} from "../../utils/Modal";
 import { motion } from 'framer-motion';
 import {requestWS} from "../../api/wsClient";
 
+const MIN_PASSWORD_LENGTH = 8;
+
+const REGISTER_ERROR_MESSAGES = {
+    "#INCOMPLETE_REQUEST": "Please fill in all required fields.",
+    "#INVALID_PASSWORD": "Password must be at least 8 characters long.",
+    "#USER_ALREADY_EXISTS": "An account with this login or email already exists.",
+};
+
 export default function Login({setPage}) {
-    localStorage.clear();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-    const [login, setLogin] = useState(undefined);
-    const [password, setPassword] = useState(undefined);
+    const [mode, setMode] = useState("login");
+    const [login, setLogin] = useState("");
+    const [fullName, setFullName] = useState("");
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [passwordConfirmation, setPasswordConfirmation] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     useEffect(() => {
         const disableContextMenu = (e) => e.preventDefault();
@@ -21,23 +34,105 @@ export default function Login({setPage}) {
     }, []);
 
     async function handleLogin() {
-        if (!login || !password) {
+        if (!login.trim() || !password) {
             showError("Error", "Some required data for authorization is missing.")
-        } else {
-            try {
-                const payload = await requestWS("auth", {
-                    "email": login,
-                    "password": password
-                }, {
-                    auth: false
-                });
+            return;
+        }
 
-                localStorage.setItem("usr_acc", JSON.stringify(payload.user));
-                localStorage.setItem("device_token", payload.token);
-                setPage("main");
-            } catch (error) {
-                showError('Error', error.message);
-            }
+        try {
+            setIsSubmitting(true);
+            const payload = await requestWS("auth", {
+                "email": login.trim(),
+                "password": password
+            }, {
+                auth: false
+            });
+
+            handleAuthSuccess(payload);
+        } catch (error) {
+            showError('Error', error.message);
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    async function handleRegister() {
+        const request = {
+            login: login.trim(),
+            full_name: fullName.trim(),
+            email: email.trim(),
+            password,
+        };
+
+        if (!request.login || !request.full_name || !request.email || !request.password || !passwordConfirmation) {
+            showError("Registration failed", "Please fill in all required fields.");
+            return;
+        }
+
+        if (request.password.length < MIN_PASSWORD_LENGTH) {
+            showError("Registration failed", `Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`);
+            return;
+        }
+
+        if (request.password !== passwordConfirmation) {
+            showError("Registration failed", "Password confirmation does not match.");
+            return;
+        }
+
+        try {
+            setIsSubmitting(true);
+            const payload = await requestWS("register_account", request, {
+                auth: false
+            });
+
+            handleAuthSuccess(payload);
+        } catch (error) {
+            showError("Registration failed", getRegistrationErrorMessage(error));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    function handleAuthSuccess(payload) {
+        localStorage.setItem("usr_acc", JSON.stringify(payload.user));
+        localStorage.setItem("device_token", payload.token);
+        setPage("main");
+    }
+
+    function getRegistrationErrorMessage(error) {
+        if (REGISTER_ERROR_MESSAGES[error?.code]) {
+            return REGISTER_ERROR_MESSAGES[error.code];
+        }
+
+        if (REGISTER_ERROR_MESSAGES[error?.message]) {
+            return REGISTER_ERROR_MESSAGES[error.message];
+        }
+
+        return error?.message || "Registration failed. Please try again.";
+    }
+
+    function resetForm() {
+        setLogin("");
+        setFullName("");
+        setEmail("");
+        setPassword("");
+        setPasswordConfirmation("");
+    }
+
+    function switchMode(nextMode) {
+        if (mode === nextMode) {
+            return;
+        }
+
+        resetForm();
+        setMode(nextMode);
+    }
+
+    function handleSubmit() {
+        if (mode === "register") {
+            handleRegister();
+        } else {
+            handleLogin();
         }
     }
 
@@ -57,9 +152,11 @@ export default function Login({setPage}) {
 
     function handleKey(e) {
         if (e.key === 'Enter') {
-            handleLogin(e);
+            handleSubmit();
         }
     }
+
+    const isRegister = mode === "register";
 
     return (
         <Box
@@ -92,7 +189,7 @@ export default function Login({setPage}) {
                             maxWidth: 450,
                             width: '100%',
                             textAlign: 'center',
-                            p: isMobile ? 3 : 5,
+                            p: isMobile ? 2 : 4,
                             borderRadius: 3,
                             boxShadow: 6,
                             mx: 2,
@@ -100,15 +197,20 @@ export default function Login({setPage}) {
                     >
                         <CardContent>
                             <motion.div custom={1} variants={textVariants}>
-                                <LockOpenIcon sx={{ fontSize: isMobile ? 60 : 80, color: 'primary.main' }} />
+                                {isRegister
+                                    ? <PersonAddAlt1Icon sx={{ fontSize: isMobile ? 54 : 72, color: 'primary.main' }} />
+                                    : <LockOpenIcon sx={{ fontSize: isMobile ? 54 : 72, color: 'primary.main' }} />
+                                }
                             </motion.div>
                             <motion.div custom={2} variants={textVariants}>
                                 <Typography variant={isMobile ? 'h4' : 'h3'} component="h1" sx={{ mt: 2, fontWeight: 'bold' }}>
-Login                                </Typography>
+                                    {isRegister ? "Register" : "Login"}
+                                </Typography>
                             </motion.div>
                             <motion.div custom={3} variants={textVariants}>
                                 <Typography sx={{ mt: 1, mb: 3, color: 'text.secondary' }}>
-                                    Enter your login details                                </Typography>
+                                    {isRegister ? "Create your account" : "Enter your login details"}
+                                </Typography>
                             </motion.div>
 
                             <motion.div custom={4} variants={textVariants}>
@@ -120,39 +222,99 @@ Login                                </Typography>
                                     sx={{ mb: 2 }}
                                     value={login}
                                     onChange={e => setLogin(e.target.value)}
-                                    onKeyPress={e => handleKey(e)}
+                                    onKeyDown={e => handleKey(e)}
 
                                 />
                             </motion.div>
-                            <motion.div custom={5} variants={textVariants}>
+                            {isRegister && (
+                                <>
+                                    <motion.div custom={5} variants={textVariants}>
+                                        <TextField
+                                            label="Full name"
+                                            variant="outlined"
+                                            fullWidth
+                                            autoComplete="name"
+                                            sx={{ mb: 2 }}
+                                            value={fullName}
+                                            onChange={e => setFullName(e.target.value)}
+                                            onKeyDown={e => handleKey(e)}
+                                        />
+                                    </motion.div>
+                                    <motion.div custom={6} variants={textVariants}>
+                                        <TextField
+                                            label="Email"
+                                            type="email"
+                                            variant="outlined"
+                                            fullWidth
+                                            autoComplete="email"
+                                            sx={{ mb: 2 }}
+                                            value={email}
+                                            onChange={e => setEmail(e.target.value)}
+                                            onKeyDown={e => handleKey(e)}
+                                        />
+                                    </motion.div>
+                                </>
+                            )}
+                            <motion.div custom={isRegister ? 7 : 5} variants={textVariants}>
                                 <TextField
                                     label="Password"
                                     type="password"
                                     variant="outlined"
-                                    autoComplete="off"
+                                    autoComplete={isRegister ? "new-password" : "current-password"}
 
                                     fullWidth
-                                    sx={{ mb: 3 }}
+                                    sx={{ mb: isRegister ? 2 : 3 }}
                                     value={password}
                                     onChange={e => setPassword(e.target.value)}
-                                    onKeyPress={e => handleKey(e)}
+                                    onKeyDown={e => handleKey(e)}
                                 />
                             </motion.div>
+                            {isRegister && (
+                                <motion.div custom={8} variants={textVariants}>
+                                    <TextField
+                                        label="Confirm password"
+                                        type="password"
+                                        variant="outlined"
+                                        autoComplete="new-password"
+                                        fullWidth
+                                        sx={{ mb: 3 }}
+                                        value={passwordConfirmation}
+                                        onChange={e => setPasswordConfirmation(e.target.value)}
+                                        onKeyDown={e => handleKey(e)}
+                                    />
+                                </motion.div>
+                            )}
 
-                            <motion.div custom={6} variants={textVariants}>
+                            <motion.div custom={isRegister ? 9 : 6} variants={textVariants}>
                                 <Button
                                     variant="contained"
                                     fullWidth
+                                    disabled={isSubmitting}
                                     sx={{
                                         py: 1.5,
                                         fontSize: '1rem',
                                         textTransform: 'none',
                                         borderRadius: 2,
                                     }}
-                                    onClick={() => {handleLogin()}}
+                                    onClick={() => {handleSubmit()}}
                                 >
-                                    Sign in
+                                    {isSubmitting ? "Please wait..." : isRegister ? "Create account" : "Sign in"}
                                 </Button>
+                            </motion.div>
+                            <motion.div custom={isRegister ? 10 : 7} variants={textVariants}>
+                                <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 2 }}>
+                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                        {isRegister ? "Already have an account?" : "New here?"}
+                                    </Typography>
+                                    <Button
+                                        variant="text"
+                                        disabled={isSubmitting}
+                                        sx={{ textTransform: 'none', minWidth: 'auto', px: 1 }}
+                                        onClick={() => switchMode(isRegister ? "login" : "register")}
+                                    >
+                                        {isRegister ? "Sign in" : "Register"}
+                                    </Button>
+                                </Stack>
                             </motion.div>
                         </CardContent>
                     </Card>

--- a/src/a/auth/Login.js
+++ b/src/a/auth/Login.js
@@ -3,10 +3,9 @@ import { Box, Card, CardContent, Typography, TextField, Button, useMediaQuery } 
 import { useTheme } from '@mui/material/styles';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import Footer from "../../components/Footer";
-import Swal from 'sweetalert2';
 import {showError} from "../../utils/Modal";
-import {sendWS, subscribeWS} from "../../utils/Websocket";
 import { motion } from 'framer-motion';
+import {requestWS} from "../../api/wsClient";
 
 export default function Login({setPage}) {
     localStorage.clear();
@@ -21,29 +20,26 @@ export default function Login({setPage}) {
         return () => document.removeEventListener('contextmenu', disableContextMenu);
     }, []);
 
-    function handleLogin(e) {
+    async function handleLogin() {
         if (!login || !password) {
             showError("Error", "Some required data for authorization is missing.")
         } else {
-            sendWS({
-                "type": "auth",
-                "email": login,
-                "password": password
-            })
+            try {
+                const payload = await requestWS("auth", {
+                    "email": login,
+                    "password": password
+                }, {
+                    auth: false
+                });
+
+                localStorage.setItem("usr_acc", JSON.stringify(payload.user));
+                localStorage.setItem("device_token", payload.token);
+                setPage("main");
+            } catch (error) {
+                showError('Error', error.message);
+            }
         }
     }
-
-    subscribeWS("auth", (payload) => {
-        localStorage.setItem("usr_acc", JSON.stringify(payload.user));
-        localStorage.setItem("device_token", payload.token);
-        setPage("main");
-    })
-
-    subscribeWS("null", (payload) => {
-        if (!payload.is_ok) {
-            showError('Error',payload['error']);
-        }
-    });
 
     const cardVariants = {
         hidden: { opacity: 0, y: 50 },
@@ -153,7 +149,7 @@ Login                                </Typography>
                                         textTransform: 'none',
                                         borderRadius: 2,
                                     }}
-                                    onClick={(e) => {handleLogin(e)}}
+                                    onClick={() => {handleLogin()}}
                                 >
                                     Sign in
                                 </Button>

--- a/src/api/wsClient.js
+++ b/src/api/wsClient.js
@@ -1,0 +1,112 @@
+import {sendWS, subscribeWS} from "../utils/Websocket";
+
+const DEFAULT_TIMEOUT = 10000;
+const ERROR_RESPONSE_TYPES = ["null", "error"];
+
+export class WSRequestError extends Error {
+    constructor(message, code = "WS_ERROR", raw = null) {
+        super(message);
+        this.name = "WSRequestError";
+        this.code = code;
+        this.raw = raw;
+    }
+}
+
+export class WSTimeoutError extends WSRequestError {
+    constructor(type, timeout) {
+        super(`WebSocket request "${type}" timed out after ${timeout}ms`, "WS_TIMEOUT");
+        this.name = "WSTimeoutError";
+        this.type = type;
+        this.timeout = timeout;
+    }
+}
+
+export function normalizeWSError(message) {
+    if (message instanceof WSRequestError) return message;
+
+    const code = message?.err_code || message?.code || "WS_ERROR";
+    const text = message?.error || message?.message || "WebSocket request failed";
+
+    return new WSRequestError(text, code, message);
+}
+
+function isErrorResponse(message) {
+    return Boolean(
+        message?.err_code ||
+        message?.is_ok === false ||
+        ERROR_RESPONSE_TYPES.includes(message?.type)
+    );
+}
+
+function withDeviceToken(payload, auth) {
+    if (auth === false) return payload;
+
+    const deviceToken = localStorage.getItem("device_token");
+    if (!deviceToken) return payload;
+
+    return {
+        ...payload,
+        device_token: deviceToken,
+    };
+}
+
+export function requestWS(type, payload = {}, options = {}) {
+    const timeout = options.timeout || DEFAULT_TIMEOUT;
+    const requestPayload = {
+        ...withDeviceToken(payload, options.auth),
+        type,
+    };
+
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        let timer = null;
+        const unsubscribers = [];
+
+        const cleanup = () => {
+            clearTimeout(timer);
+            unsubscribers.forEach(unsubscribe => unsubscribe());
+        };
+
+        const settle = (handler, value) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            handler(value);
+        };
+
+        const onSuccess = (message) => {
+            if (isErrorResponse(message)) {
+                settle(reject, normalizeWSError(message));
+                return;
+            }
+
+            settle(resolve, message);
+        };
+
+        const onError = (message) => {
+            settle(reject, normalizeWSError(message));
+        };
+
+        timer = setTimeout(() => {
+            settle(reject, new WSTimeoutError(type, timeout));
+        }, timeout);
+
+        unsubscribers.push(subscribeWS(type, onSuccess));
+        if (settled) return;
+
+        ERROR_RESPONSE_TYPES.forEach(errorType => {
+            if (errorType !== type) {
+                unsubscribers.push(subscribeWS(errorType, onError));
+            }
+        });
+        if (settled) return;
+
+        sendWS(requestPayload).catch(error => {
+            settle(reject, normalizeWSError({
+                code: "WS_SEND_FAILED",
+                message: error?.message || "Failed to send WebSocket request",
+                error,
+            }));
+        });
+    });
+}

--- a/src/utils/Websocket.js
+++ b/src/utils/Websocket.js
@@ -11,9 +11,8 @@ const sendQueue = []
 const listeners = {};
 const queues = {};
 
-let serverKey = null;
 let keyPair = null;
-const url = "ws://localhost:8000/apiws"
+const url = process.env.REACT_APP_WS_URL || "ws://localhost:8000/apiws"
 export let key = null;
 
 export function pushMessage(msg) {
@@ -116,11 +115,11 @@ export async function sendWS(data) {
         sendQueue.push(data)
         return
     }
-if (key !== null) {
-    await socket.send(await encrypt(JSON.stringify(data), key))
-} else {
-    await socket.send(JSON.stringify(data))
-}
+    if (key !== null) {
+        await socket.send(await encrypt(JSON.stringify(data), key))
+    } else {
+        await socket.send(JSON.stringify(data))
+    }
 }
 export function subscribeWS(type, callback) {
     if (!listeners[type]) {


### PR DESCRIPTION
- add requestWS helper with request-style Promise API
- attach device_token automatically for authorized WS requests
- normalize backend WS errors from err_code, null/error, and is_ok=false responses
- add request timeout handling
- move WebSocket URL to REACT_APP_WS_URL with local fallback
- migrate login flow away from direct sendWS/subscribeWS usage