### PR TITLE
Add frontend logout flow

### DIFF
--- a/src/a/A_app.js
+++ b/src/a/A_app.js
@@ -4,12 +4,25 @@ import ServerError from "../system-pages/ServerError"
 import Loader from "../utils/Loaders"
 import Login from "./auth/Login";
 import MainContainer from "./MainContainer";
+import {requestWS} from "../api/wsClient";
 
 let timeout = null;
 
 export default function App_a() {
     const [status, setStatus] = useState("connecting")
     const [page, setPage] = useState("loading")
+
+    async function handleLogout() {
+        try {
+            await requestWS("logout");
+        } catch (error) {
+            console.warn("Logout request failed", error);
+        } finally {
+            localStorage.removeItem("usr_acc");
+            localStorage.removeItem("device_token");
+            setPage("auth");
+        }
+    }
 
     useEffect(() => {
         let inttimeout = null;
@@ -54,7 +67,7 @@ export default function App_a() {
         return <ServerError/>
     }
     if (page === "main") {
-        return <MainContainer setPage={setPage} />
+        return <MainContainer onLogout={handleLogout} />
     }
     if (page === "loading") {
         return (

--- a/src/a/MainContainer.js
+++ b/src/a/MainContainer.js
@@ -1,10 +1,21 @@
-export default function Dashboard () {
+import {Button, Stack} from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+export default function Dashboard ({onLogout}) {
     const user = JSON.parse(localStorage.getItem("usr_acc")) || {
         first_name: "Unknown",
         last_name: "User",
         role: "Unknown role"
     };
+
     return (
-        <>logged in<br/> {JSON.stringify(user, null, 2)}</>
+        <Stack spacing={2} alignItems="flex-start">
+            <div>
+                logged in<br/> {JSON.stringify(user, null, 2)}
+            </div>
+            <Button variant="outlined" startIcon={<LogoutIcon />} onClick={onLogout}>
+                Log out
+            </Button>
+        </Stack>
     );
 }


### PR DESCRIPTION
- Add logout handler that calls the backend WebSocket logout message
- Clear usr_acc and device_token from localStorage after logout
- Redirect the user back to the auth page
- Add a visible Log out button in the authenticated screen