### PR TITLE
refactor frontend styling structure

### DIFF
--- a/src/a/auth/Login.js
+++ b/src/a/auth/Login.js
@@ -1,13 +1,14 @@
 import {useEffect, useState} from 'react';
-import { Box, Card, CardContent, Typography, TextField, Button, useMediaQuery, Stack } from '@mui/material';
+import { Card, CardContent, Typography, TextField, Button, useMediaQuery, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
-import Footer from "../../components/Footer";
 import {showError} from "../../utils/Modal";
 import { motion } from 'framer-motion';
 import {requestWS} from "../../api/wsClient";
 import {storeAuthData} from "./authStorage";
+import CenteredPage from "../../ui/CenteredPage";
+import {cardEntranceVariants, staggeredItemVariants} from "../../ui/animations";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -136,20 +137,6 @@ export default function Login({setPage}) {
         }
     }
 
-    const cardVariants = {
-        hidden: { opacity: 0, y: 50 },
-        visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } }
-    };
-
-    const textVariants = {
-        hidden: { opacity: 0, y: 20 },
-        visible: (i = 1) => ({
-            opacity: 1,
-            y: 0,
-            transition: { delay: i * 0.2, duration: 0.2 }
-        })
-    };
-
     function handleKey(e) {
         if (e.key === 'Enter') {
             handleSubmit();
@@ -159,29 +146,11 @@ export default function Login({setPage}) {
     const isRegister = mode === "register";
 
     return (
-        <Box
-            sx={{
-                minHeight: '98vh',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                bgcolor: 'background.default',
-                overflow: 'hidden',
-            }}
-        >
-            <Box
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    flex: '1 0 auto',
-                    width: '100%',
-                }}
-            >
+        <CenteredPage>
                 <motion.div
                     initial="hidden"
                     animate="visible"
-                    variants={cardVariants}
+                    variants={cardEntranceVariants}
                     style={{ display: 'flex', justifyContent: 'center', width: '100%' }}
                 >
                     <Card
@@ -190,33 +159,31 @@ export default function Login({setPage}) {
                             width: '100%',
                             textAlign: 'center',
                             p: isMobile ? 2 : 4,
-                            borderRadius: 3,
                             boxShadow: 6,
                             mx: 2,
                         }}
                     >
                         <CardContent>
-                            <motion.div custom={1} variants={textVariants}>
+                            <motion.div custom={1} variants={staggeredItemVariants}>
                                 {isRegister
                                     ? <PersonAddAlt1Icon sx={{ fontSize: isMobile ? 54 : 72, color: 'primary.main' }} />
                                     : <LockOpenIcon sx={{ fontSize: isMobile ? 54 : 72, color: 'primary.main' }} />
                                 }
                             </motion.div>
-                            <motion.div custom={2} variants={textVariants}>
+                            <motion.div custom={2} variants={staggeredItemVariants}>
                                 <Typography variant={isMobile ? 'h4' : 'h3'} component="h1" sx={{ mt: 2, fontWeight: 'bold' }}>
                                     {isRegister ? "Register" : "Login"}
                                 </Typography>
                             </motion.div>
-                            <motion.div custom={3} variants={textVariants}>
+                            <motion.div custom={3} variants={staggeredItemVariants}>
                                 <Typography sx={{ mt: 1, mb: 3, color: 'text.secondary' }}>
                                     {isRegister ? "Create your account" : "Enter your login details"}
                                 </Typography>
                             </motion.div>
 
-                            <motion.div custom={4} variants={textVariants}>
+                            <motion.div custom={4} variants={staggeredItemVariants}>
                                 <TextField
                                     label="Login"
-                                    variant="outlined"
                                     fullWidth
                                     autoComplete="off"
                                     sx={{ mb: 2 }}
@@ -228,10 +195,9 @@ export default function Login({setPage}) {
                             </motion.div>
                             {isRegister && (
                                 <>
-                                    <motion.div custom={5} variants={textVariants}>
+                                    <motion.div custom={5} variants={staggeredItemVariants}>
                                         <TextField
                                             label="Full name"
-                                            variant="outlined"
                                             fullWidth
                                             autoComplete="name"
                                             sx={{ mb: 2 }}
@@ -240,11 +206,10 @@ export default function Login({setPage}) {
                                             onKeyDown={e => handleKey(e)}
                                         />
                                     </motion.div>
-                                    <motion.div custom={6} variants={textVariants}>
+                                    <motion.div custom={6} variants={staggeredItemVariants}>
                                         <TextField
                                             label="Email"
                                             type="email"
-                                            variant="outlined"
                                             fullWidth
                                             autoComplete="email"
                                             sx={{ mb: 2 }}
@@ -255,11 +220,10 @@ export default function Login({setPage}) {
                                     </motion.div>
                                 </>
                             )}
-                            <motion.div custom={isRegister ? 7 : 5} variants={textVariants}>
+                            <motion.div custom={isRegister ? 7 : 5} variants={staggeredItemVariants}>
                                 <TextField
                                     label="Password"
                                     type="password"
-                                    variant="outlined"
                                     autoComplete={isRegister ? "new-password" : "current-password"}
 
                                     fullWidth
@@ -270,11 +234,10 @@ export default function Login({setPage}) {
                                 />
                             </motion.div>
                             {isRegister && (
-                                <motion.div custom={8} variants={textVariants}>
+                                <motion.div custom={8} variants={staggeredItemVariants}>
                                     <TextField
                                         label="Confirm password"
                                         type="password"
-                                        variant="outlined"
                                         autoComplete="new-password"
                                         fullWidth
                                         sx={{ mb: 3 }}
@@ -285,7 +248,7 @@ export default function Login({setPage}) {
                                 </motion.div>
                             )}
 
-                            <motion.div custom={isRegister ? 9 : 6} variants={textVariants}>
+                            <motion.div custom={isRegister ? 9 : 6} variants={staggeredItemVariants}>
                                 <Button
                                     variant="contained"
                                     fullWidth
@@ -293,15 +256,13 @@ export default function Login({setPage}) {
                                     sx={{
                                         py: 1.5,
                                         fontSize: '1rem',
-                                        textTransform: 'none',
-                                        borderRadius: 2,
                                     }}
                                     onClick={() => {handleSubmit()}}
                                 >
                                     {isSubmitting ? "Please wait..." : isRegister ? "Create account" : "Sign in"}
                                 </Button>
                             </motion.div>
-                            <motion.div custom={isRegister ? 10 : 7} variants={textVariants}>
+                            <motion.div custom={isRegister ? 10 : 7} variants={staggeredItemVariants}>
                                 <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 2 }}>
                                     <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                                         {isRegister ? "Already have an account?" : "New here?"}
@@ -319,9 +280,6 @@ export default function Login({setPage}) {
                         </CardContent>
                     </Card>
                 </motion.div>
-            </Box>
-
-            <Footer/>
-        </Box>
+        </CenteredPage>
     );
 }

--- a/src/a/tournaments/TournamentDetailView.js
+++ b/src/a/tournaments/TournamentDetailView.js
@@ -103,6 +103,25 @@ function getUserLabel(user) {
     return user.full_name || user.login || user.email || user._id || "Unnamed user";
 }
 
+function getUserId(userOrId) {
+    return typeof userOrId === "object" && userOrId !== null ? userOrId._id : userOrId;
+}
+
+function getTournamentCreatorLabel(tournament, currentUser) {
+    const createdBy = tournament.created_by;
+    const creatorId = getUserId(createdBy);
+
+    if (createdBy && typeof createdBy === "object") {
+        return getUserLabel(createdBy);
+    }
+
+    if (creatorId && creatorId === currentUser?._id) {
+        return getUserLabel(currentUser);
+    }
+
+    return tournament.creator_name || tournament.created_by_name || "Unknown creator";
+}
+
 function mergeUsers(...userLists) {
     const usersById = new Map();
 
@@ -424,8 +443,10 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
     }
 
     const participants = Array.isArray(tournament.participants) ? tournament.participants : [];
-    const canManageTournament = currentUser?.role === "organizer" && tournament.created_by === currentUser?._id;
+    const creatorId = getUserId(tournament.created_by);
+    const canManageTournament = currentUser?.role === "organizer" && creatorId === currentUser?._id;
     const currentStatus = tournament.status || "Draft";
+    const creatorLabel = getTournamentCreatorLabel(tournament, currentUser);
 
     return (
         <Stack spacing={2}>
@@ -491,7 +512,7 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
                     <Stack spacing={1.5}>
                         <DetailRow label="Start date" value={formatDate(tournament.start_date)}/>
                         <DetailRow label="End date" value={formatDate(tournament.end_date)}/>
-                        <DetailRow label="Creator" value={tournament.created_by}/>
+                        <DetailRow label="Creator" value={creatorLabel}/>
                         <DetailRow label="Created" value={formatDateTime(tournament.created_at)}/>
                     </Stack>
                 </Stack>

--- a/src/global.css
+++ b/src/global.css
@@ -1,14 +1,6 @@
-* {
-    user-select: none;
-    font-family: Georgia, serif;
-}
-
 .swal2-show-fast {
     animation: swal2-show 0.1s !important;
 }
 .swal2-hide-fast {
     animation: swal2-hide 0.1s !important;
-}
-body {
-    margin: 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import {BrowserRouter} from "react-router-dom";
+import {CssBaseline, ThemeProvider} from "@mui/material";
 import "./global.css";
+import theme from "./theme/theme";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <React.StrictMode>
-        <BrowserRouter>
-
+        <ThemeProvider theme={theme}>
+            <CssBaseline/>
+            <BrowserRouter>
                 <App/>
-        </BrowserRouter>
+            </BrowserRouter>
+        </ThemeProvider>
     </React.StrictMode>
 );

--- a/src/system-pages/NotFound.js
+++ b/src/system-pages/NotFound.js
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
-import { Box, Card, CardContent, Typography, Button, useMediaQuery, Link as MuiLink } from '@mui/material';
+import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { Link } from 'react-router-dom';
-import Footer from "../components/Footer";
+import CenteredPage from "../ui/CenteredPage";
+import StatusCard from "../ui/StatusCard";
 
 export default function NotFound() {
     const theme = useTheme();
@@ -16,66 +17,15 @@ export default function NotFound() {
     }, []);
 
     return (
-        <Box
-            sx={{
-                minHeight: '98vh',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                bgcolor: 'background.default',
-                overflow: 'hidden',
-            }}
-        >
-            <Box
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    flex: '1 0 auto',
-                    width: '100%',
-                }}
-            >
-                <Card
-                    sx={{
-                        maxWidth: 500,
-                        width: '100%',
-                        textAlign: 'center',
-                        p: isMobile ? 3 : 5,
-                        borderRadius: 3,
-                        boxShadow: 6,
-                        mx: 2,
-                    }}
-                >
-                    <CardContent>
-                        <ErrorOutlineIcon sx={{ fontSize: isMobile ? 60 : 100, color: 'primary.main' }} />
-                        <Typography variant={isMobile ? 'h3' : 'h1'} component="h1" sx={{ mt: 2, fontWeight: 'bold' }}>
-                            404
-                        </Typography>
-                        <Typography variant={isMobile ? 'h5' : 'h4'} sx={{ mt: 1, color: 'text.secondary' }}>
-                            Page not found
-                        </Typography>
-                        <Typography sx={{ mt: 2, mb: 4, color: 'text.secondary' }}>
-                            Unfortunately, there is no such page on our platform. You may have made a mistake in the link or the page has been moved.
-                        </Typography>
-                        <Link to="/">
-                            <Button
-                                variant="contained"
-                                sx={{
-                                    px: 4,
-                                    py: 1.5,
-                                    fontSize: '1rem',
-                                    textTransform: 'none',
-                                    borderRadius: 2,
-                                }}
-                            >
-                                Back
-                            </Button>
-                        </Link>
-                    </CardContent>
-                </Card>
-            </Box>
-
-        <Footer/>
-        </Box>
+        <CenteredPage>
+            <StatusCard
+                icon={<ErrorOutlineIcon sx={{fontSize: isMobile ? 60 : 100, color: 'primary.main'}}/>}
+                code="404"
+                title="Page not found"
+                description="Unfortunately, there is no such page on our platform. You may have made a mistake in the link or the page has been moved."
+                actionLabel="Back"
+                actionComponent={(action) => <Link to="/">{action}</Link>}
+            />
+        </CenteredPage>
     );
 }

--- a/src/system-pages/ServerError.js
+++ b/src/system-pages/ServerError.js
@@ -1,10 +1,11 @@
 import {useEffect} from 'react';
-import {Box, Card, CardContent, Typography, Button, useMediaQuery} from '@mui/material';
+import {useMediaQuery} from '@mui/material';
 import {useTheme} from '@mui/material/styles';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import {Link} from 'react-router-dom';
-import Footer from "../components/Footer";
 import RefreshIcon from '@mui/icons-material/Refresh';
+import CenteredPage from "../ui/CenteredPage";
+import StatusCard from "../ui/StatusCard";
 
 export default function ServerError() {
     const theme = useTheme();
@@ -17,90 +18,23 @@ export default function ServerError() {
     }, []);
 
     return (
-        <Box
-            sx={{
-                minHeight: '98vh',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                bgcolor: 'background.default',
-                overflow: 'hidden',
-            }}
-        >
-            <Box
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    flex: '1 0 auto',
-                    width: '100%',
-                }}
-            >
-                <Card
-                    sx={{
-                        maxWidth: 500,
-                        width: '100%',
-                        textAlign: 'center',
-                        p: isMobile ? 3 : 5,
-                        borderRadius: 3,
-                        boxShadow: 6,
-                        mx: 2,
-                    }}
-                >
-                    <CardContent>
-                        <ErrorOutlineIcon
-                            sx={{
-                                fontSize: isMobile ? 60 : 100,
-                                color: 'error.main',
-                            }}
-                        />
-
-                        <Typography
-                            variant={isMobile ? 'h3' : 'h1'}
-                            component="h1"
-                            sx={{mt: 2, fontWeight: 'bold'}}
-                        >
-                            500
-                        </Typography>
-
-                        <Typography
-                            variant={isMobile ? 'h5' : 'h4'}
-                            sx={{mt: 1, color: 'text.secondary'}}
-                        >
-                            Server error
-                        </Typography>
-
-                        <Typography
-                            sx={{mt: 2, mb: 4, color: 'text.secondary'}}
-                        >
-                            An internal server error has occurred. We are working to fix it.
-                            Try refreshing the page or coming back later.
-                        </Typography>
-
-                        <Link to="/" onClick={(event) => {
-                            event.preventDefault();
-                            window.location.reload();
-                        }}>
-                            <Button
-                                variant="contained"
-                                startIcon={<RefreshIcon/>}
-                                sx={{
-                                    px: 4,
-                                    py: 1.5,
-                                    fontSize: '1rem',
-                                    textTransform: 'none',
-                                    borderRadius: 2,
-                                }}
-                            >
-                                Refresh page
-                            </Button>
-                        </Link>
-
-                    </CardContent>
-                </Card>
-            </Box>
-
-            <Footer/>
-        </Box>
+        <CenteredPage>
+            <StatusCard
+                icon={<ErrorOutlineIcon sx={{fontSize: isMobile ? 60 : 100, color: 'error.main'}}/>}
+                code="500"
+                title="Server error"
+                description="An internal server error has occurred. We are working to fix it. Try refreshing the page or coming back later."
+                actionLabel="Refresh page"
+                actionIcon={<RefreshIcon/>}
+                actionComponent={(action) => (
+                    <Link to="/" onClick={(event) => {
+                        event.preventDefault();
+                        window.location.reload();
+                    }}>
+                        {action}
+                    </Link>
+                )}
+            />
+        </CenteredPage>
     );
 }

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,0 +1,71 @@
+import { createTheme } from "@mui/material/styles";
+
+const BORDER_RADIUS = 8;
+const baseTheme = createTheme();
+
+const theme = createTheme({
+    palette: {
+        primary: {
+            main: baseTheme.palette.primary.main,
+        },
+        background: {
+            default: baseTheme.palette.background.default,
+            paper: baseTheme.palette.background.paper,
+        },
+    },
+    typography: {
+        fontFamily: baseTheme.typography.fontFamily,
+        button: {
+            textTransform: "none",
+        },
+    },
+    shape: {
+        borderRadius: BORDER_RADIUS,
+    },
+    spacing: 8,
+    components: {
+        MuiCssBaseline: {
+            styleOverrides: {
+                body: {
+                    margin: 0,
+                },
+            },
+        },
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: BORDER_RADIUS * 2,
+                    textTransform: "none",
+                },
+            },
+        },
+        MuiCard: {
+            styleOverrides: {
+                root: {
+                    borderRadius: BORDER_RADIUS * 3,
+                },
+            },
+        },
+        MuiPaper: {
+            styleOverrides: {
+                rounded: {
+                    borderRadius: BORDER_RADIUS,
+                },
+            },
+        },
+        MuiTextField: {
+            defaultProps: {
+                variant: "outlined",
+            },
+        },
+        MuiOutlinedInput: {
+            styleOverrides: {
+                root: {
+                    borderRadius: BORDER_RADIUS,
+                },
+            },
+        },
+    },
+});
+
+export default theme;

--- a/src/ui/CenteredPage.js
+++ b/src/ui/CenteredPage.js
@@ -1,0 +1,33 @@
+import {Box} from "@mui/material";
+import Footer from "../components/Footer";
+
+export default function CenteredPage({children, footer = true, contentSx, sx}) {
+    return (
+        <Box
+            sx={{
+                minHeight: "98vh",
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: footer ? "space-between" : "center",
+                bgcolor: "background.default",
+                overflow: "hidden",
+                ...sx,
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    flex: footer ? "1 0 auto" : undefined,
+                    width: "100%",
+                    ...contentSx,
+                }}
+            >
+                {children}
+            </Box>
+
+            {footer && <Footer/>}
+        </Box>
+    );
+}

--- a/src/ui/StatusCard.js
+++ b/src/ui/StatusCard.js
@@ -1,0 +1,59 @@
+import {Button, Card, CardContent, Typography, useMediaQuery} from "@mui/material";
+import {useTheme} from "@mui/material/styles";
+
+export default function StatusCard({
+    icon,
+    code,
+    title,
+    description,
+    actionLabel,
+    actionIcon,
+    onAction,
+    actionComponent,
+    maxWidth = 500,
+}) {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+    const action = (
+        <Button
+            variant="contained"
+            startIcon={actionIcon}
+            sx={{
+                px: 4,
+                py: 1.5,
+                fontSize: "1rem",
+            }}
+            onClick={onAction}
+        >
+            {actionLabel}
+        </Button>
+    );
+
+    return (
+        <Card
+            sx={{
+                maxWidth,
+                width: "100%",
+                textAlign: "center",
+                p: isMobile ? 3 : 5,
+                boxShadow: 6,
+                mx: 2,
+            }}
+        >
+            <CardContent>
+                {icon}
+                <Typography variant={isMobile ? "h3" : "h1"} component="h1" sx={{mt: 2, fontWeight: "bold"}}>
+                    {code}
+                </Typography>
+                <Typography variant={isMobile ? "h5" : "h4"} sx={{mt: 1, color: "text.secondary"}}>
+                    {title}
+                </Typography>
+                <Typography sx={{mt: 2, mb: 4, color: "text.secondary"}}>
+                    {description}
+                </Typography>
+                {actionComponent ? actionComponent(action) : action}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/ui/animations.js
+++ b/src/ui/animations.js
@@ -1,0 +1,20 @@
+import { keyframes } from "@mui/system";
+
+export const cardEntranceVariants = {
+    hidden: { opacity: 0, y: 50 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: "easeOut" } },
+};
+
+export const staggeredItemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: (i = 1) => ({
+        opacity: 1,
+        y: 0,
+        transition: { delay: i * 0.2, duration: 0.2 },
+    }),
+};
+
+export const rotate = keyframes`
+  0% { transform: rotate(0deg);}
+  100% { transform: rotate(360deg);}
+`;

--- a/src/utils/Loaders.js
+++ b/src/utils/Loaders.js
@@ -1,14 +1,10 @@
 import React from "react";
 import CircularProgress from "@mui/material/CircularProgress";
-import { styled, keyframes } from "@mui/system";
-import Box from "@mui/material/Box";
+import { styled } from "@mui/system";
 import { Card, CardContent, Typography, useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-
-const rotate = keyframes`
-  0% { transform: rotate(0deg);}
-  100% { transform: rotate(360deg);}
-`;
+import CenteredPage from "../ui/CenteredPage";
+import {rotate} from "../ui/animations";
 
 const Spinner = styled(CircularProgress)(() => ({
     color: "#00adef",
@@ -27,24 +23,13 @@ export default function Loader({ text = "Loading..." }) {
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     return (
-        <Box
-            sx={{
-                minHeight: '98vh',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-                bgcolor: 'background.default',
-                overflow: 'hidden',
-            }}
-        >
+        <CenteredPage footer={false}>
             <Card
                 sx={{
                     maxWidth: 400,
                     width: '100%',
                     textAlign: 'center',
                     p: isMobile ? 3 : 5,
-                    borderRadius: 3,
                     boxShadow: 6,
                     mx: 2,
                 }}
@@ -67,6 +52,6 @@ export default function Loader({ text = "Loading..." }) {
                     </Typography>
                 </CardContent>
             </Card>
-        </Box>
+        </CenteredPage>
     );
 }


### PR DESCRIPTION
- add centralized MUI theme and app ThemeProvider
- extract shared centered page and status card UI components
- move shared animation variants into a reusable module
- reduce duplicated styling in login, error, and loader views
- remove global user-select rule while keeping global CSS minimal