### PR TITLE
implement current user tournaments list with navigation to detail view

### DIFF
--- a/src/a/MainContainer.js
+++ b/src/a/MainContainer.js
@@ -1,6 +1,6 @@
 import {useEffect, useMemo, useState} from "react";
 import {matchPath, useLocation, useNavigate} from "react-router-dom";
-import {Box, Paper, Stack, Typography} from "@mui/material";
+import {Box, Button, Chip, Divider, Paper, Stack, Typography} from "@mui/material";
 import AdminRoleManagement from "./admin/AdminRoleManagement";
 import {getStoredUser} from "./auth/authStorage";
 import AuthenticatedLayout from "./layout/AuthenticatedLayout";
@@ -8,6 +8,7 @@ import {getNavigationForRole} from "./layout/appNavigation";
 import {normalizeUser} from "./layout/userUtils";
 import OrganizerTournamentCreation from "./organizer/OrganizerTournamentCreation";
 import TournamentDetailView from "./tournaments/TournamentDetailView";
+import TournamentListView from "./tournaments/TournamentListView";
 
 const PAGE_TITLES = {
     overview: "Overview",
@@ -31,49 +32,261 @@ function WorkspacePanel({title, subtitle}) {
     );
 }
 
-function Overview({user}) {
-    const details = [
-        ["Name", user.displayName],
-        ["Email", user.email || "-"],
+function TeamWorkspace({user, onOpenTournaments}) {
+    const references = [
+        ["Team name", user.full_name || user.displayName],
         ["Login", user.login || "-"],
-        ["Role", user.roleLabel],
+        ["Contact email", user.email || "-"],
+        ["Account id", user._id || "-"],
+    ];
+
+    const actions = [
+        {
+            title: "Register for tournaments",
+            description: "Open the tournaments list to join available competitions during registration.",
+        },
+        {
+            title: "Track participation",
+            description: "Check current status, dates, and participant details for tournaments assigned to your team.",
+        },
+        {
+            title: "Submit your project",
+            description: "When a tournament starts, use its detail page to send the repository, demo video, and optional links.",
+        },
     ];
 
     return (
-        <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
-            <Typography variant="h5" component="h2" sx={{fontWeight: 800}}>
-                Account summary
-            </Typography>
-            <Stack spacing={1.5} sx={{mt: 2}}>
-                {details.map(([label, value]) => (
-                    <Box
-                        key={label}
-                        sx={{
-                            display: "grid",
-                            gridTemplateColumns: {xs: "1fr", sm: "140px 1fr"},
-                            gap: {xs: 0.25, sm: 2},
-                        }}
+        <Stack spacing={2}>
+            <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                <Stack spacing={2}>
+                    <Stack direction={{xs: "column", sm: "row"}} spacing={1.5} alignItems={{xs: "flex-start", sm: "center"}}>
+                        <Box sx={{minWidth: 0, flex: 1}}>
+                            <Typography variant="h5" component="h2" sx={{fontWeight: 800, wordBreak: "break-word"}}>
+                                {user.full_name || user.displayName}
+                            </Typography>
+                            <Typography sx={{mt: 0.5, color: "text.secondary"}}>
+                                Team workspace for participation, registration, and submissions.
+                            </Typography>
+                        </Box>
+                        <Chip label="Team account" sx={{fontWeight: 700}}/>
+                    </Stack>
+
+                    <Button
+                        variant="contained"
+                        onClick={onOpenTournaments}
+                        sx={{textTransform: "none", alignSelf: "flex-start"}}
                     >
-                        <Typography variant="body2" sx={{color: "text.secondary"}}>
-                            {label}
-                        </Typography>
-                        <Typography sx={{fontWeight: 600, wordBreak: "break-word"}}>
-                            {value}
-                        </Typography>
-                    </Box>
-                ))}
-            </Stack>
-        </Paper>
+                        Open tournaments
+                    </Button>
+                </Stack>
+            </Paper>
+
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: {xs: "1fr", md: "1.2fr 1fr"},
+                    gap: 2,
+                }}
+            >
+                <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                    <Typography variant="h6" component="h2" sx={{fontWeight: 800}}>
+                        Team profile
+                    </Typography>
+                    <Stack spacing={1.5} sx={{mt: 2}}>
+                        {references.map(([label, value]) => (
+                            <Box
+                                key={label}
+                                sx={{
+                                    display: "grid",
+                                    gridTemplateColumns: {xs: "1fr", sm: "140px 1fr"},
+                                    gap: {xs: 0.25, sm: 2},
+                                }}
+                            >
+                                <Typography variant="body2" sx={{color: "text.secondary"}}>
+                                    {label}
+                                </Typography>
+                                <Typography sx={{fontWeight: 600, wordBreak: "break-word"}}>
+                                    {value}
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Stack>
+                </Paper>
+
+                <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                    <Typography variant="h6" component="h2" sx={{fontWeight: 800}}>
+                        Access
+                    </Typography>
+                    <Stack spacing={1.25} sx={{mt: 2}}>
+                        <DetailTag label="Role" value={user.roleLabel}/>
+                        <DetailTag label="Login" value={user.login || "-"}/>
+                        <DetailTag label="Email" value={user.email || "-"}/>
+                    </Stack>
+                </Paper>
+            </Box>
+
+            <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                <Typography variant="h6" component="h2" sx={{fontWeight: 800}}>
+                    What your team can do
+                </Typography>
+                <Stack divider={<Divider flexItem/>} spacing={2} sx={{mt: 2}}>
+                    {actions.map(action => (
+                        <Box key={action.title}>
+                            <Typography sx={{fontWeight: 700}}>
+                                {action.title}
+                            </Typography>
+                            <Typography variant="body2" sx={{mt: 0.5, color: "text.secondary"}}>
+                                {action.description}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Stack>
+            </Paper>
+        </Stack>
     );
 }
 
-function renderPage(activeItem, user, onAuthError, tournamentId) {
+function DetailTag({label, value}) {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+                px: 1.5,
+                py: 1.25,
+                borderRadius: 1,
+                bgcolor: "grey.50",
+            }}
+        >
+            <Typography variant="body2" sx={{color: "text.secondary"}}>
+                {label}
+            </Typography>
+            <Typography sx={{fontWeight: 700, wordBreak: "break-word", textAlign: "right"}}>
+                {value}
+            </Typography>
+        </Box>
+    );
+}
+
+function Overview({user}) {
+    const quickActions = [
+        {
+            title: "Browse tournaments",
+            description: "Open the tournaments section to track active competitions, statuses, and deadlines.",
+        },
+        {
+            title: "Use your role workspace",
+            description: user.role === "team"
+                ? "Go to Team to manage participation context and team-specific activity."
+                : user.role === "jury"
+                    ? "Go to Judging to review assignments and judging-related work."
+                    : user.role === "organizer"
+                        ? "Go to Organizer to create tournaments and manage tournament flow."
+                        : "Use the role-specific sections in the sidebar for your current responsibilities.",
+        },
+        {
+            title: "Open tournament details",
+            description: "Each tournament page gives access to participants, current state, and next actions.",
+        },
+    ];
+
+    const workspaceNotes = [
+        ["Current role", user.roleLabel],
+        ["Available sections", user.role === "admin" ? "Overview, Tournaments, Role management" : "Overview and role-specific navigation"],
+        ["Session", "Authenticated"],
+    ];
+
+    return (
+        <Stack spacing={2}>
+            <Paper
+                sx={{
+                    p: {xs: 2.5, sm: 3.5},
+                    borderRadius: 1,
+                    background: "linear-gradient(135deg, #f7f4ed 0%, #ffffff 100%)",
+                    border: theme => `1px solid ${theme.palette.divider}`,
+                }}
+            >
+                <Stack spacing={2}>
+                    <Box>
+                        <Typography
+                            variant="overline"
+                            sx={{letterSpacing: "0.12em", color: "text.secondary", fontWeight: 700}}
+                        >
+                            Workspace overview
+                        </Typography>
+                        <Typography variant="h4" component="h2" sx={{mt: 0.5, fontWeight: 800}}>
+                            Welcome back, {user.displayName}
+                        </Typography>
+                        <Typography sx={{mt: 1, maxWidth: 720, color: "text.secondary"}}>
+                            This is the main workspace entry point. Use it to orient yourself, then move into tournaments
+                            or your role-specific section for actual work.
+                        </Typography>
+                    </Box>
+
+                    <Stack direction={{xs: "column", sm: "row"}} spacing={1.25} flexWrap="wrap" useFlexGap>
+                        <Chip label={user.roleLabel} sx={{fontWeight: 700, borderRadius: 1}}/>
+                        <Chip label="Workspace active" variant="outlined" sx={{borderRadius: 1}}/>
+                    </Stack>
+                </Stack>
+            </Paper>
+
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: {xs: "1fr", lg: "1.4fr 0.9fr"},
+                    gap: 2,
+                }}
+            >
+                <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                    <Typography variant="h6" component="h3" sx={{fontWeight: 800}}>
+                        Getting started
+                    </Typography>
+                    <Stack spacing={1.5} sx={{mt: 2}}>
+                        {quickActions.map(item => (
+                            <Box
+                                key={item.title}
+                                sx={{
+                                    p: 1.5,
+                                    borderRadius: 1,
+                                    bgcolor: "grey.50",
+                                    border: theme => `1px solid ${theme.palette.divider}`,
+                                }}
+                            >
+                                <Typography sx={{fontWeight: 700, wordBreak: "break-word"}}>
+                                    {item.title}
+                                </Typography>
+                                <Typography variant="body2" sx={{mt: 0.5, color: "text.secondary"}}>
+                                    {item.description}
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Stack>
+                </Paper>
+
+                <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                    <Typography variant="h6" component="h3" sx={{fontWeight: 800}}>
+                        Workspace status
+                    </Typography>
+                    <Stack spacing={1.25} sx={{mt: 2}}>
+                        {workspaceNotes.map(([label, value]) => (
+                            <DetailTag key={label} label={label} value={value}/>
+                        ))}
+                    </Stack>
+                </Paper>
+            </Box>
+        </Stack>
+    );
+}
+
+function renderPage(activeItem, user, onAuthError, tournamentId, onOpenTournaments) {
     if (activeItem === "role-management" && user.role === "admin") {
         return <AdminRoleManagement currentUser={user}/>;
     }
 
     if (activeItem === "team") {
-        return <WorkspacePanel title="Team workspace" subtitle="Team tournament activity will appear here." />;
+        return <TeamWorkspace user={user} onOpenTournaments={onOpenTournaments}/>;
     }
 
     if (activeItem === "judging") {
@@ -89,7 +302,7 @@ function renderPage(activeItem, user, onAuthError, tournamentId) {
             return <TournamentDetailView tournamentId={tournamentId} currentUser={user} onAuthError={onAuthError}/>;
         }
 
-        return <WorkspacePanel title="Available tournaments" subtitle="Available tournaments will appear here." />;
+        return <TournamentListView onAuthError={onAuthError}/>;
     }
 
     return <Overview user={user}/>;
@@ -143,7 +356,7 @@ export default function MainContainer({onLogout}) {
                         {user.roleLabel}
                     </Typography>
                 </Box>
-                {renderPage(visibleItem, user, onLogout, tournamentId)}
+                {renderPage(visibleItem, user, onLogout, tournamentId, () => handleNavigate("tournaments"))}
             </Stack>
         </AuthenticatedLayout>
     );

--- a/src/a/tournaments/TournamentDetailView.js
+++ b/src/a/tournaments/TournamentDetailView.js
@@ -682,10 +682,13 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
 
     const participants = Array.isArray(tournament.participants) ? tournament.participants : [];
     const creatorId = getUserId(tournament.created_by);
-    const canManageStatus = currentUser?.role === "organizer" && creatorId === currentUser?._id;
-    const canManageParticipants = currentUser?.role === "organizer" || canManageStatus;
+    const isTournamentCreator =
+        currentUser?.role === "organizer" && creatorId === currentUser?._id;
+    const canManageStatus = isTournamentCreator;
+    const canManageParticipants = isTournamentCreator;
     const currentStatus = tournament.status || "Draft";
     const creatorLabel = getTournamentCreatorLabel(tournament, currentUser);
+    
 
     return (
         <Stack spacing={2}>

--- a/src/a/tournaments/TournamentDetailView.js
+++ b/src/a/tournaments/TournamentDetailView.js
@@ -46,6 +46,15 @@ const STATUS_ERROR_MESSAGES = {
     "Tournament not found": "Tournament was not found.",
 };
 
+const SUBMISSION_ERROR_MESSAGES = {
+    "Authentication required": "Please sign in again.",
+    "Invalid token": "Please sign in again.",
+    "Access denied": "You do not have permission to submit for this tournament.",
+    "Tournament not found": "Tournament was not found.",
+    "SubmissionClosed": "Submission is closed for this tournament.",
+    "Required data is missing": "Repository and demo video links are required.",
+};
+
 function getAssignmentErrorMessage(error) {
     const rawMessage = error?.message || error?.raw?.error || "Request failed. Please try again.";
     return ASSIGNMENT_ERROR_MESSAGES[rawMessage] || rawMessage;
@@ -63,6 +72,11 @@ function getStatusErrorMessage(error) {
     if (code === "NOT_FOUND") return "Tournament was not found.";
 
     return STATUS_ERROR_MESSAGES[rawMessage] || rawMessage;
+}
+
+function getSubmissionErrorMessage(error) {
+    const rawMessage = error?.message || error?.raw?.error || "Submission failed. Please try again.";
+    return SUBMISSION_ERROR_MESSAGES[rawMessage] || rawMessage;
 }
 
 function DetailRow({label, value}) {
@@ -119,7 +133,7 @@ function getTournamentCreatorLabel(tournament, currentUser) {
         return getUserLabel(currentUser);
     }
 
-    return tournament.creator_name || tournament.created_by_name || "Unknown creator";
+    return tournament.creator_name || tournament.created_by_name || "Admin";
 }
 
 function mergeUsers(...userLists) {
@@ -132,6 +146,230 @@ function mergeUsers(...userLists) {
     });
 
     return Array.from(usersById.values());
+}
+
+function getCurrentTeamSubmission(tournament, currentUser) {
+    if (tournament?.my_submission && typeof tournament.my_submission === "object") {
+        return tournament.my_submission;
+    }
+
+    if (Array.isArray(tournament?.submissions)) {
+        return tournament.submissions.find(submission => submission?.team_id === currentUser?._id) || null;
+    }
+
+    return null;
+}
+
+function getSubmissionDeadline(tournament) {
+    return tournament?.submission_deadline || tournament?.end_date || null;
+}
+
+function isSubmissionClosedForTournament(tournament) {
+    if (tournament?.submission_closed === true) {
+        return true;
+    }
+
+    const deadline = getSubmissionDeadline(tournament);
+    if (!deadline) {
+        return false;
+    }
+
+    const parsedDeadline = new Date(deadline);
+    if (Number.isNaN(parsedDeadline.getTime())) {
+        return false;
+    }
+
+    return Date.now() > parsedDeadline.getTime();
+}
+
+function normalizeTournamentStatus(status) {
+    return typeof status === "string" ? status.trim().toLowerCase() : "";
+}
+
+function canTeamSubmitForStatus(status) {
+    const normalizedStatus = normalizeTournamentStatus(status);
+
+    return normalizedStatus === "running" || normalizedStatus === "started" || normalizedStatus === "finished";
+}
+
+function TeamTournamentSubmission({tournament, currentUser, onReload, onAuthError}) {
+    const currentStatus = tournament.status || "Draft";
+    const isRegistered = Array.isArray(tournament.participants)
+        && tournament.participants.some(participant => participant?._id === currentUser?._id);
+    const currentSubmission = getCurrentTeamSubmission(tournament, currentUser);
+    const submissionClosed = isSubmissionClosedForTournament(tournament);
+    const canAccessSubmission = currentUser?.role === "team" && isRegistered && canTeamSubmitForStatus(currentStatus);
+    const [isFormOpen, setIsFormOpen] = useState(Boolean(currentSubmission));
+    const [form, setForm] = useState({
+        repositoryUrl: currentSubmission?.repository_url || "",
+        videoDemoUrl: currentSubmission?.video_demo_url || "",
+        liveDemoUrl: currentSubmission?.live_demo_url || "",
+        description: currentSubmission?.description || "",
+    });
+    const [error, setError] = useState("");
+    const [success, setSuccess] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        setForm({
+            repositoryUrl: currentSubmission?.repository_url || "",
+            videoDemoUrl: currentSubmission?.video_demo_url || "",
+            liveDemoUrl: currentSubmission?.live_demo_url || "",
+            description: currentSubmission?.description || "",
+        });
+        setIsFormOpen(Boolean(currentSubmission));
+    }, [currentSubmission, tournament._id]);
+
+    if (!canAccessSubmission) {
+        return null;
+    }
+
+    function updateField(field, value) {
+        setForm(previous => ({
+            ...previous,
+            [field]: value,
+        }));
+    }
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+
+        if (!form.repositoryUrl.trim() || !form.videoDemoUrl.trim()) {
+            setError("Repository and demo video links are required.");
+            setSuccess("");
+            return;
+        }
+
+        try {
+            setIsSubmitting(true);
+            setError("");
+            setSuccess("");
+
+            await requestWS("upsert_tournament_submission", {
+                tournament_id: tournament._id,
+                repository_url: form.repositoryUrl.trim(),
+                video_demo_url: form.videoDemoUrl.trim(),
+                live_demo_url: form.liveDemoUrl.trim() || null,
+                description: form.description.trim() || null,
+            });
+
+            await onReload?.();
+            setSuccess("Submission saved successfully.");
+        } catch (submitError) {
+            setError(getSubmissionErrorMessage(submitError));
+
+            if (isAuthError(submitError)) {
+                onAuthError?.();
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+            <Stack spacing={2}>
+                <Box>
+                    <Typography variant="h6" component="h2" sx={{fontWeight: 800}}>
+                        Submission
+                    </Typography>
+                    <Typography variant="body2" sx={{mt: 0.5, color: "text.secondary"}}>
+                        Submit your GitHub repository and demo video after the tournament starts.
+                    </Typography>
+                </Box>
+
+                {submissionClosed ? (
+                    <Alert severity="warning">
+                        Submission is closed for this tournament.
+                    </Alert>
+                ) : (
+                    <Button
+                        variant={isFormOpen ? "outlined" : "contained"}
+                        onClick={() => setIsFormOpen(previous => !previous)}
+                        sx={{textTransform: "none", alignSelf: "flex-start"}}
+                    >
+                        {isFormOpen ? "Hide submission form" : (currentSubmission ? "Edit submission" : "Open submission form")}
+                    </Button>
+                )}
+
+                {currentSubmission && (
+                    <Stack spacing={1}>
+                        <DetailRow label="Repository" value={currentSubmission.repository_url}/>
+                        <DetailRow label="Video demo" value={currentSubmission.video_demo_url}/>
+                        <DetailRow label="Live demo" value={currentSubmission.live_demo_url}/>
+                        <DetailRow label="Submitted" value={formatDateTime(currentSubmission.updated_at || currentSubmission.created_at)}/>
+                    </Stack>
+                )}
+
+                {isFormOpen && !submissionClosed && (
+                    <Stack spacing={2} component="form" onSubmit={handleSubmit}>
+                        {error && (
+                            <Alert severity="error" onClose={() => setError("")}>
+                                {error}
+                            </Alert>
+                        )}
+
+                        {success && (
+                            <Alert severity="success" onClose={() => setSuccess("")}>
+                                {success}
+                            </Alert>
+                        )}
+
+                        <TextField
+                            label="GitHub repository"
+                            value={form.repositoryUrl}
+                            onChange={event => updateField("repositoryUrl", event.target.value)}
+                            fullWidth
+                            required
+                            autoComplete="off"
+                            placeholder="https://github.com/org/project"
+                        />
+                        <TextField
+                            label="Video demo"
+                            value={form.videoDemoUrl}
+                            onChange={event => updateField("videoDemoUrl", event.target.value)}
+                            fullWidth
+                            required
+                            autoComplete="off"
+                            placeholder="https://youtube.com/... or https://drive.google.com/..."
+                        />
+                        <TextField
+                            label="Live demo"
+                            value={form.liveDemoUrl}
+                            onChange={event => updateField("liveDemoUrl", event.target.value)}
+                            fullWidth
+                            autoComplete="off"
+                            placeholder="https://your-demo.example.com"
+                        />
+                        <TextField
+                            label="Short description"
+                            value={form.description}
+                            onChange={event => updateField("description", event.target.value)}
+                            fullWidth
+                            multiline
+                            minRows={4}
+                            placeholder="What was built and how to run it."
+                        />
+
+                        <Stack direction={{xs: "column", sm: "row"}} spacing={1.5} alignItems={{xs: "stretch", sm: "center"}}>
+                            <Button
+                                type="submit"
+                                variant="contained"
+                                startIcon={isSubmitting ? <CircularProgress color="inherit" size={18}/> : <SaveIcon/>}
+                                disabled={isSubmitting}
+                                sx={{textTransform: "none", minWidth: 180}}
+                            >
+                                {currentSubmission ? "Update submission" : "Submit project"}
+                            </Button>
+                            <Typography variant="body2" sx={{color: "text.secondary"}}>
+                                Required: GitHub repository and demo video link.
+                            </Typography>
+                        </Stack>
+                    </Stack>
+                )}
+            </Stack>
+        </Paper>
+    );
 }
 
 function TournamentParticipantAssignment({tournament, onAssigned, onAuthError}) {
@@ -444,7 +682,8 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
 
     const participants = Array.isArray(tournament.participants) ? tournament.participants : [];
     const creatorId = getUserId(tournament.created_by);
-    const canManageTournament = currentUser?.role === "organizer" && creatorId === currentUser?._id;
+    const canManageStatus = currentUser?.role === "organizer" && creatorId === currentUser?._id;
+    const canManageParticipants = currentUser?.role === "admin" || canManageStatus;
     const currentStatus = tournament.status || "Draft";
     const creatorLabel = getTournamentCreatorLabel(tournament, currentUser);
 
@@ -465,7 +704,7 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
                             <Typography variant="h5" component="h2" sx={{fontWeight: 800, wordBreak: "break-word"}}>
                                 {tournament.title}
                             </Typography>
-                            {canManageTournament ? (
+                            {canManageStatus ? (
                                 <Stack direction="row" spacing={1} alignItems="center">
                                     <TextField
                                         select
@@ -518,6 +757,13 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
                 </Stack>
             </Paper>
 
+            <TeamTournamentSubmission
+                tournament={tournament}
+                currentUser={currentUser}
+                onReload={loadTournament}
+                onAuthError={onAuthError}
+            />
+
             <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
                 <Stack spacing={2}>
                     <Stack direction="row" spacing={1} alignItems="center">
@@ -560,7 +806,7 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
                 </Stack>
             </Paper>
 
-            {canManageTournament && (
+            {canManageParticipants && (
                 <TournamentParticipantAssignment
                     tournament={tournament}
                     onAssigned={loadTournament}

--- a/src/a/tournaments/TournamentDetailView.js
+++ b/src/a/tournaments/TournamentDetailView.js
@@ -133,7 +133,7 @@ function getTournamentCreatorLabel(tournament, currentUser) {
         return getUserLabel(currentUser);
     }
 
-    return tournament.creator_name || tournament.created_by_name || "Admin";
+    return tournament.creator_name || tournament.created_by_name || "Tournament Organizer";
 }
 
 function mergeUsers(...userLists) {
@@ -683,7 +683,7 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
     const participants = Array.isArray(tournament.participants) ? tournament.participants : [];
     const creatorId = getUserId(tournament.created_by);
     const canManageStatus = currentUser?.role === "organizer" && creatorId === currentUser?._id;
-    const canManageParticipants = currentUser?.role === "admin" || canManageStatus;
+    const canManageParticipants = currentUser?.role === "Tournament Organizer" || canManageStatus;
     const currentStatus = tournament.status || "Draft";
     const creatorLabel = getTournamentCreatorLabel(tournament, currentUser);
 

--- a/src/a/tournaments/TournamentDetailView.js
+++ b/src/a/tournaments/TournamentDetailView.js
@@ -683,7 +683,7 @@ export default function TournamentDetailView({tournamentId: tournamentIdProp, cu
     const participants = Array.isArray(tournament.participants) ? tournament.participants : [];
     const creatorId = getUserId(tournament.created_by);
     const canManageStatus = currentUser?.role === "organizer" && creatorId === currentUser?._id;
-    const canManageParticipants = currentUser?.role === "Tournament Organizer" || canManageStatus;
+    const canManageParticipants = currentUser?.role === "organizer" || canManageStatus;
     const currentStatus = tournament.status || "Draft";
     const creatorLabel = getTournamentCreatorLabel(tournament, currentUser);
 

--- a/src/a/tournaments/TournamentListView.js
+++ b/src/a/tournaments/TournamentListView.js
@@ -1,0 +1,174 @@
+import {useCallback, useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Divider,
+    Paper,
+    Stack,
+    Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import {requestWS} from "../../api/wsClient";
+import {formatDate, isAuthError} from "./tournamentFormatters";
+
+const ACTUAL_TOURNAMENT_ERROR_MESSAGES = {
+    "Authentication required": "Please sign in again.",
+    "Invalid token": "Please sign in again.",
+};
+
+function getActualTournamentsErrorMessage(error) {
+    const rawMessage = error?.message || error?.raw?.error || "Could not load tournaments. Please try again.";
+
+    return ACTUAL_TOURNAMENT_ERROR_MESSAGES[rawMessage] || rawMessage;
+}
+
+function formatTournamentDates(startDate, endDate) {
+    return `${formatDate(startDate)} - ${formatDate(endDate)}`;
+}
+
+export default function TournamentListView({onAuthError}) {
+    const navigate = useNavigate();
+    const [tournaments, setTournaments] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    const loadTournaments = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            setError("");
+
+            const payload = await requestWS("get_actual_tournaments");
+            setTournaments(Array.isArray(payload.tournaments) ? payload.tournaments : []);
+        } catch (loadError) {
+            setTournaments([]);
+            setError(getActualTournamentsErrorMessage(loadError));
+
+            if (isAuthError(loadError)) {
+                onAuthError?.();
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    }, [onAuthError]);
+
+    useEffect(() => {
+        loadTournaments();
+    }, [loadTournaments]);
+
+    if (isLoading) {
+        return (
+            <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                <Stack direction="row" spacing={1.5} alignItems="center">
+                    <CircularProgress size={22}/>
+                    <Typography>Loading tournaments...</Typography>
+                </Stack>
+            </Paper>
+        );
+    }
+
+    if (error) {
+        return (
+            <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                <Stack spacing={2} alignItems="flex-start">
+                    <Alert severity="error" sx={{width: "100%"}}>
+                        {error}
+                    </Alert>
+                    <Button
+                        variant="outlined"
+                        startIcon={<RefreshIcon/>}
+                        onClick={loadTournaments}
+                        sx={{textTransform: "none"}}
+                    >
+                        Try again
+                    </Button>
+                </Stack>
+            </Paper>
+        );
+    }
+
+    if (tournaments.length === 0) {
+        return (
+            <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+                <Stack spacing={1}>
+                    <Typography variant="h5" component="h2" sx={{fontWeight: 800}}>
+                        No tournaments yet
+                    </Typography>
+                    <Typography sx={{color: "text.secondary"}}>
+                        You do not have any active tournaments assigned right now.
+                    </Typography>
+                </Stack>
+            </Paper>
+        );
+    }
+
+    return (
+        <Paper sx={{p: {xs: 2, sm: 3}, borderRadius: 1}}>
+            <Stack spacing={2}>
+                <Box>
+                    <Typography variant="h5" component="h2" sx={{fontWeight: 800}}>
+                        Your tournaments
+                    </Typography>
+                    <Typography sx={{mt: 0.5, color: "text.secondary"}}>
+                        Tournaments available for your current role.
+                    </Typography>
+                </Box>
+
+                <Stack divider={<Divider flexItem/>} spacing={2}>
+                    {tournaments.map(tournament => (
+                        <Box
+                            key={tournament._id || tournament.title}
+                            sx={{
+                                display: "grid",
+                                gridTemplateColumns: {xs: "1fr", sm: "1fr auto"},
+                                gap: 1.5,
+                                alignItems: "center",
+                            }}
+                        >
+                            <Box sx={{minWidth: 0}}>
+                                <Stack direction={{xs: "column", sm: "row"}} spacing={1} alignItems={{xs: "flex-start", sm: "center"}}>
+                                    <Typography variant="h6" component="h3" sx={{fontWeight: 700, wordBreak: "break-word"}}>
+                                        {tournament.title || "Untitled tournament"}
+                                    </Typography>
+                                    <Chip
+                                        label={tournament.status || "Draft"}
+                                        size="small"
+                                        sx={{fontWeight: 700}}
+                                    />
+                                </Stack>
+                                <Typography variant="body2" sx={{mt: 0.75, color: "text.secondary"}}>
+                                    {formatTournamentDates(tournament.start_date, tournament.end_date)}
+                                </Typography>
+                                {tournament.description && (
+                                    <Typography variant="body2" sx={{mt: 1, wordBreak: "break-word"}}>
+                                        {tournament.description}
+                                    </Typography>
+                                )}
+                            </Box>
+
+                            {tournament._id && (
+                                <Button
+                                    type="button"
+                                    variant="outlined"
+                                    startIcon={<VisibilityIcon/>}
+                                    onClick={() => navigate(`/tournaments/${tournament._id}`)}
+                                    sx={{
+                                        textTransform: "none",
+                                        justifySelf: {xs: "start", sm: "end"},
+                                        minWidth: 130,
+                                    }}
+                                >
+                                    View details
+                                </Button>
+                            )}
+                        </Box>
+                    ))}
+                </Stack>
+            </Stack>
+        </Paper>
+    );
+}


### PR DESCRIPTION
Implemented the tournaments frontend flow and improved role-specific workspace behavior.

  Changes in this branch:

  - Replaced the /tournaments placeholder with a real tournaments list loaded via get_actual_tournaments
  - Added loading, empty, error, and retry states for the tournaments list
  - Connected each tournament item to the existing /tournaments/:tournamentId detail page
  - Extended tournament detail behavior for teams with a submission form UI for started/running/finished tournaments
  - Removed team self-registration from the frontend
  - Allowed admins on the frontend to manage tournament participants through the existing assignment UI
  - Improved the Overview page into a cleaner workspace dashboard
  - Reworked the Team tab so it is separate from Tournaments and no longer duplicates Overview
  - Removed raw creator id fallback from tournament details so creator is not shown as an ObjectId anymore